### PR TITLE
notusingCode, just use Http.Status Code

### DIFF
--- a/src/main/java/hello/postpractice/advice/MyAdvice.java
+++ b/src/main/java/hello/postpractice/advice/MyAdvice.java
@@ -25,7 +25,7 @@ public class MyAdvice {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     protected CommonResult userNotFoundException(HttpServletRequest request, UserNotFoundCException e) {
         log.info(e.getMessage());
-        return responseService.getFailResult();
+        return responseService.getFailResult(e.getMessage());
     }
 
     /*
@@ -35,46 +35,46 @@ public class MyAdvice {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     protected CommonResult emailLoginFailedCException(HttpServletRequest request, EmailNotFailedCException e) {
         log.info(e.getMessage());
-        return responseService.getFailResult();
+        return responseService.getFailResult(e.getMessage());
     }
 
     @ExceptionHandler(PasswordFailCException.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     protected CommonResult passwordFailException(HttpServletRequest request, PasswordFailCException e) {
         log.info(e.getMessage());
-        return responseService.getFailResult();
+        return responseService.getFailResult(e.getMessage());
     }
 
     @ExceptionHandler(EmailExsistFailedCException.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     protected CommonResult emailExsistFailedCException(HttpServletRequest request, EmailExsistFailedCException e) {
         log.info(e.getMessage());
-        return responseService.getFailResult();
+        return responseService.getFailResult(e.getMessage());
     }
 
     @ExceptionHandler(UnMatchedUserCException.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     protected CommonResult unMathedUserException(HttpServletRequest request, UnMatchedUserCException e) {
         log.info(e.getMessage());
-        return responseService.getFailResult();
+        return responseService.getFailResult(e.getMessage());
     }
     @ExceptionHandler(PostNotFoundCException.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     protected CommonResult postNotFoundException(HttpServletRequest request, PostNotFoundCException e) {
         log.info(e.getMessage());
-        return responseService.getFailResult();
+        return responseService.getFailResult(e.getMessage());
     }
     @ExceptionHandler(CommentNotFoundCException.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     protected CommonResult commentNotFoundCException(HttpServletRequest request, CommentNotFoundCException e) {
         log.info(e.getMessage());
-        return responseService.getFailResult();
+        return responseService.getFailResult(e.getMessage());
     }
     @ExceptionHandler(NullPointerException.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     protected CommonResult catchNullPointException(HttpServletRequest request, CommentNotFoundCException e) {
         log.info(e.getMessage());
-        return responseService.getFailResult();
+        return responseService.getFailResult(e.getMessage());
     }
 
 }

--- a/src/main/java/hello/postpractice/model/response/CommonResult.java
+++ b/src/main/java/hello/postpractice/model/response/CommonResult.java
@@ -6,12 +6,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class CommonResult {
-    // 응답 성공여부 true , false
-    private boolean success;
-
-    // 응답 코드 번호 (0이상이면 정상)
-    private int code;
-
     //응답 메시지
     private String msg;
 

--- a/src/main/java/hello/postpractice/service/ResponseService.java
+++ b/src/main/java/hello/postpractice/service/ResponseService.java
@@ -12,19 +12,12 @@ public class ResponseService {
 
     // enum으로 api 요청 결과에 대한 code, message를 정의합니다.
     public enum CommonResponse {
-        SUCCESS(0, "성공하였습니디."),
-        FAIL(-1, "실패하였습니다.");
+        SUCCESS("성공하였습니다.");
 
-        int code;
         String msg;
 
-        CommonResponse(int code, String msg) {
-            this.code = code;
+        CommonResponse(String msg) {
             this.msg = msg;
-        }
-
-        public int getCode() {
-            return code;
         }
 
         public String getMsg() {
@@ -52,21 +45,17 @@ public class ResponseService {
         return result;
     }
     // 실패 결과만 처리하는 메소드
-    public CommonResult getFailResult() {
+    public CommonResult getFailResult(String errormsg) {
         CommonResult result = new CommonResult();
-        setFailResult(result);
+        setFailResult(result, errormsg);
         return result;
     }
     // 결과 모델에 api 요청 성공 데이터를 세팅해주는 메소드
     private void setSuccessResult(CommonResult result) {
-        result.setSuccess(true);
-        result.setCode(CommonResponse.SUCCESS.getCode());
         result.setMsg(CommonResponse.SUCCESS.getMsg());
     }
     // API 요청 실패 시 응답 모델을 실패 데이터로 세팅
-    private void setFailResult(CommonResult result) {
-        result.setSuccess(false);
-        result.setCode(CommonResponse.FAIL.getCode());
-        result.setMsg(CommonResponse.FAIL.getMsg());
+    private void setFailResult(CommonResult result,String errormsg) {
+        result.setMsg(errormsg+"인해 실패하였습니다.");
     }
 }


### PR DESCRIPTION
에러 코드를 개인적으로 표준화하여 사용하고있었고,  다음과 같은 이유로 error.msg 전달용으로만 사용하려고변경한다.
1. http.status code가 있는데, 개인적인 에러 코드를 json에 넘겨주면 혼동을 초래할수있다.
2. 성공한 이유는 적을 필요없다. 필요한 데이터 그리고 200 status코드만 필요하다.