### PR TITLE
apply_OAuth2_Success_with just accessToken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ out/
 /src/main/resources/application-jwt.yml
 
 # 풀리퀘스트 테스트
+
+## oauth key
+/src/main/resources/application-oauth.properties

--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,12 @@ dependencies {
 	implementation 'io.springfox:springfox-swagger2:2.6.1'
 	implementation 'io.springfox:springfox-swagger-ui:2.6.1'
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+
+	//spring-boot-starter-oauth2-client와 spring-security-oauth2-jose를 기본으로 관리함
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
 }
+

--- a/src/main/java/hello/postpractice/config/JwtProvider.java
+++ b/src/main/java/hello/postpractice/config/JwtProvider.java
@@ -39,13 +39,11 @@ public class JwtProvider {
     }
 
     // Jwt 생성
-    public String createToken(String userPk, UserLoginResponseDto userLoginResponseDto) {
+    public String createToken(String userPk, List roles) {
 
         // user 구분을 위해 Claims에 User Pk값 넣어줌
         Claims claims = Jwts.claims().setSubject(userPk);  //클래임에 userPK 추가
-        claims.put("roles", userLoginResponseDto.getRoles()); //권한 추가
-        claims.put("email", userLoginResponseDto.getEmail());
-        claims.put("username", userLoginResponseDto.getEmail());
+        claims.put("roles", roles.stream().map(Object::toString)); //권한 추가
         Date now = new Date(); // 생성날짜, 만료날짜를 위한 Date
 
         String token = Jwts.builder()

--- a/src/main/java/hello/postpractice/controller/SignController.java
+++ b/src/main/java/hello/postpractice/controller/SignController.java
@@ -37,7 +37,7 @@ public class SignController {
         String password = loginMap.get("password");
         UserLoginResponseDto userLoginDto = userService.login(email, password);
 
-        String token = jwtProvider.createToken(String.valueOf(userLoginDto.getId()), userLoginDto);
+        String token = jwtProvider.createToken(String.valueOf(userLoginDto.getId()), userLoginDto.getRoles());
         Map<String, String> tokenMap = new HashMap<>();
         tokenMap.put("Authorization", token);
 

--- a/src/main/java/hello/postpractice/domain/OAuthAttributes.java
+++ b/src/main/java/hello/postpractice/domain/OAuthAttributes.java
@@ -1,0 +1,52 @@
+package hello.postpractice.domain;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.Map;
+@Getter
+public class OAuthAttributes {
+    private Map<String, Object> attributes;
+    private String nameAttributeKey;
+    private String name;
+    private String email;
+
+    @Builder
+    public OAuthAttributes(Map<String, Object> attributes,
+                           String nameAttributeKey, String name,
+                           String email) {
+        this.attributes = attributes;
+        this.nameAttributeKey= nameAttributeKey;
+        this.name = name;
+        this.email = email;
+    }
+
+    // OAuth2User에서 반환하는 사용자 정보는 Map이기 때문에 값 하나하나를 변환해야한다.
+    public static OAuthAttributes of(String registrationId,
+                                     String userNameAttributeName,
+                                     Map<String, Object> attributes) {
+        return ofGoogle(userNameAttributeName, attributes);
+    }
+
+    private static OAuthAttributes ofGoogle(String userNameAttributeName,
+                                            Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    // 가입할때 기본 권한 User를 주며, User엔티티를 생성, OAuthAttributes에서 엔티티를 생성하는 시점은 처음가입시이다.
+    public User toEntity() {
+        return User.builder()
+                .username(name)
+                .email(email)
+                .roles(Collections.singletonList("ROLE_USER"))
+                .build();
+    }
+
+}

--- a/src/main/java/hello/postpractice/domain/User.java
+++ b/src/main/java/hello/postpractice/domain/User.java
@@ -29,7 +29,7 @@ public class User extends BaseTimeEntity implements UserDetails {
     @Column(name="username")
     private String username;
 
-    @Column(name="nickname",nullable = false)
+    @Column(name="nickname", nullable = true)
     private String nickname;
 
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
@@ -39,10 +39,6 @@ public class User extends BaseTimeEntity implements UserDetails {
     @ElementCollection(fetch = FetchType.EAGER)
     @Builder.Default
     private List<String> roles = new ArrayList<>();
-
-    public void updateNickName(String nickname) {
-        this.nickname = nickname;
-    }
 
 
     // 사용자의 권한을 콜렉션 형태로 반환
@@ -92,5 +88,9 @@ public class User extends BaseTimeEntity implements UserDetails {
     public boolean isEnabled() {
         // 계정이 사용 가능한지 확인하는 로직
         return true; // true -> 사용 가능
+    }
+    public User update(String username){
+        this.username = username;
+        return this;
     }
 }

--- a/src/main/java/hello/postpractice/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/hello/postpractice/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,57 @@
+package hello.postpractice.handler;
+
+import hello.postpractice.advice.exception.EmailNotFailedCException;
+import hello.postpractice.config.JwtProvider;
+import hello.postpractice.domain.OAuthAttributes;
+import hello.postpractice.domain.User;
+import hello.postpractice.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.neo4j.Neo4jProperties;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        String targetUrl = determineTargetUrl(request, response, authentication);
+
+        if (response.isCommitted()){
+            logger.debug("Response has already been committed. Unable to redirect to" + targetUrl);
+            return;
+        }
+        clearAuthenticationAttributes(request);
+        getRedirectStrategy().sendRedirect(request,response,targetUrl);
+    }
+    protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        String targetUrl = "http://localhost:8081/loginWithOAuth";
+        DefaultOAuth2User defaultOAuth2User = (DefaultOAuth2User) authentication.getPrincipal();//OidcUser??DefaultOidcUser??
+        User user = userRepository.findByEmail(defaultOAuth2User.getAttribute("email")).orElseThrow(EmailNotFailedCException::new);
+
+        String token = jwtProvider.createToken(String.valueOf(user.getId()),user.getRoles()); //role 안잡힐껄?
+        return UriComponentsBuilder.fromUriString(targetUrl)
+                .queryParam("token",token)
+                .build().toUriString();
+    }
+
+
+}

--- a/src/main/java/hello/postpractice/service/CustomOAuth2UserService.java
+++ b/src/main/java/hello/postpractice/service/CustomOAuth2UserService.java
@@ -1,0 +1,54 @@
+package hello.postpractice.service;
+
+import hello.postpractice.domain.OAuthAttributes;
+import hello.postpractice.domain.User;
+import hello.postpractice.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import javax.naming.AuthenticationException;
+import java.nio.file.attribute.UserPrincipal;
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        // 현재 로그인 진행중인 서비스를 구분하는 코드.(현재 구글만하므로 필요없음 확장성)
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        // OAuth2 로그인 진행 시 키가 되는 필드값을 이야기한다. PrimaryKey의미, 구글의 경우 기본적 코드 지원, 네이버 카카오는 지원안함. 구글 기본 코드는 "sub"이다
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        // OAuth2UserService를 통해 가져온 OAuth2User의 attribute를 담을클래스
+        OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+
+        User user = saveOrUpdate(attributes);
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+                attributes.getAttributes(),
+                attributes.getNameAttributeKey());
+    }
+    private User saveOrUpdate(OAuthAttributes attributes){
+        //구글 사용자 정보가 업데이트 되었을 때를 대비하여 update 기능도 같이 구현
+        User user = userRepository.findByEmail(attributes.getEmail())
+                .map(entity -> entity.update(attributes.getName()))
+                .orElse(attributes.toEntity()); // 처음가입시 toEntity()로 생성됨.
+
+        return userRepository.save(user);
+
+    }
+}

--- a/src/main/resources/application-oauth.properties
+++ b/src/main/resources/application-oauth.properties
@@ -1,0 +1,3 @@
+spring.security.oauth2.client.registration.google.client-id=152217934133-06rd9c69ntspf4540l44ifoo8cv5ml22.apps.googleusercontent.com
+spring.security.oauth2.client.registration.google.client-secret=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
+spring.security.oauth2.client.registration.google.scope=profile,email

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,7 @@ logging.level.org.springframework.security=DEBUG
 spring.jpa.properties.hibernate.format_sql=true
 logging.level.org.hibernate.SQL=debug
 spring.jpa.show-sql=true
+
+
+# oauth ??
+spring.profiles.include=oauth


### PR DESCRIPTION
accessToken으로 OAuth2 구성
아래 로직
### 1. 클라이언트→내 서버 OAuth2지정로 지정된 요청

### 2. 내 서버→클라이언트 redirect_uri주소를 담은 응답으로 redirect 302를 주며 Authorization Server로 redirect 시킴

 쿼리로redirect_uri=http://localhost:8080/login/oauth2/code/google 담고있음
### 3.클라이언트→Authorization Server 리다이렉트로 로그인성공할 경우, Authorization Server→내 서버에 Authorization Code Response로 응답

### 4. 내 서버→ Authorization Server 요청시 Access Token Request With Authorization Code

### 5. Authorization Server→내 서버 Access Token을 응답함

### 6. 내서버→ Resource Server에 User Info with Access Token으로 요청함

### 7. ResourceServer→ 내서버 UserInfo응답함

### 8. 내 서버에서의 처리

- user info를 DB저장
- jwt accesstoken 발급

### 9. 내 서버→클라이언트에게 서버가 원하는 주소로 redirect로 시킴( 내서버의 access-token 값 전달!)
10. 9번 클라이언트는 해당주소로 요청,이후 localStorage에 accesstoken을 갖게됨. 