### PR TITLE
method:Post feature/logout success

### DIFF
--- a/src/main/java/hello/postpractice/config/SecurityConfig.java
+++ b/src/main/java/hello/postpractice/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -16,7 +17,11 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.web.cors.CorsConfigurationSource;
+
+import javax.servlet.http.HttpServletResponse;
 
 @RequiredArgsConstructor
 @EnableWebSecurity // 1
@@ -37,9 +42,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter { // 2
     protected void configure(HttpSecurity http) throws Exception {
         http
                 .httpBasic().disable()
-                .csrf()
-//                .and()
-                .disable()
+                .csrf().disable()
+                .cors() //cors 관련해서 허용
+                .and()
 
 
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
@@ -47,12 +52,12 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter { // 2
                 .authorizeRequests()
                 .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()//allow CORS option calls
                 .antMatchers("/", "/test/**").permitAll() //test진행하기위해 test/이후 경로는 인증필요없음
-                .antMatchers("/login", "/signup").permitAll()
+                .antMatchers("/login", "/signup", "/logout").permitAll()
 //                .anyRequest().hasRole("USER")
                 .anyRequest().authenticated()
                 .and()
                 .logout()
-                .logoutSuccessUrl("/")
+                .logoutSuccessHandler((new HttpStatusReturningLogoutSuccessHandler(HttpStatus.OK)))
                 .and()
                 // oauth관련 설정
                 // oauth관련 설정 추가

--- a/src/main/java/hello/postpractice/controller/SignController.java
+++ b/src/main/java/hello/postpractice/controller/SignController.java
@@ -1,8 +1,10 @@
 package hello.postpractice.controller;
 
 import hello.postpractice.config.JwtProvider;
+import hello.postpractice.domain.User;
 import hello.postpractice.domain.UserLoginResponseDto;
 import hello.postpractice.domain.UserSignupRequestDto;
+import hello.postpractice.model.response.CommonResult;
 import hello.postpractice.model.response.SingleResult;
 import hello.postpractice.service.ResponseService;
 import hello.postpractice.service.UserService;
@@ -10,9 +12,15 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.util.ObjectUtils;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -58,5 +66,17 @@ public class SignController {
                 .build();
         Long signupId = userService.signup(userSignupRequestDto);
         return responseService.getSingleResult(signupId);
+    }
+    @PostMapping("/logout")
+    public CommonResult logout(HttpServletRequest request, HttpServletResponse response){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null){
+            authentication.setAuthenticated(false);
+            new SecurityContextLogoutHandler().logout(request,response,authentication);
+            request.getSession().invalidate();
+            return responseService.getSuccessResult();
+        } else {
+            throw new RuntimeException("로그인안되어있음");
+        }
     }
 }


### PR DESCRIPTION
logout을 method:post 를 요청할때 CORS이슈가 터졌다.

분명 logout을 method:post로 구현하였고, 분명 해당 logout 함수가 들어있는 전체 컨트롤러에 

`@CrossOrigin(origins="*", allowedHeaders = "*")`

가 설정되어있었다.

하지만 계속해서 CORS이슈가 터졌다.

## 이유?

CORS는 결국 헤더에 allowedHeader가 적혀있지 않은 response를 받아서 브라우져에서 경고를 띄우는것이다.

원인은 바로 SecurityConfig에서 logout()을 설정해놓았고 logout()이 성공하면 자동으로 logoutsuccessurl()을 통해 자동으로 redirect가 되기때문이다. 하지만 이 redirect가 되는 페이지는 allowedHeader 옵션이 없었기 때문에 CORS이슈가 터진것이다.

## 해결책

생각해볼수있는 해결책은 두가지다

- logoutSuccessHandler를 활용하는 방법(이는 logoutsuccessurl()이 동작하지않음) 
`.logoutSuccessHandler((new HttpStatusReturningLogoutSuccessHandler(HttpStatus.*OK*)))`>> 하지만 이또한 이 핸들러가 응답해주는 header에는 allowedheader가 포함되어있지않기때문에 따로 핸들러나 응답을 직접 클래스로 구현해서 응답해줘야한다.
- 다른방법으로는 SecurityConfig에서 cors()를 추가해줘서, 모든 요청에 대해 cors() 를 허용해주는것이였다.