### PR TITLE
Feature/change http status response

### DIFF
--- a/src/main/java/hello/postpractice/advice/MyAdvice.java
+++ b/src/main/java/hello/postpractice/advice/MyAdvice.java
@@ -22,7 +22,7 @@ public class MyAdvice {
      * 유저를 찾지 못했을 때 발생시키는 예외
      */
     @ExceptionHandler(UserNotFoundCException.class)
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
     protected CommonResult userNotFoundException(HttpServletRequest request, UserNotFoundCException e) {
         log.info(e.getMessage());
         return responseService.getFailResult(e.getMessage());
@@ -32,40 +32,40 @@ public class MyAdvice {
     이메일 찾지못했을때 발생시키는 예외
      */
     @ExceptionHandler(EmailNotFailedCException.class)
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
     protected CommonResult emailLoginFailedCException(HttpServletRequest request, EmailNotFailedCException e) {
         log.info(e.getMessage());
         return responseService.getFailResult(e.getMessage());
     }
 
     @ExceptionHandler(PasswordFailCException.class)
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
     protected CommonResult passwordFailException(HttpServletRequest request, PasswordFailCException e) {
         log.info(e.getMessage());
         return responseService.getFailResult(e.getMessage());
     }
 
     @ExceptionHandler(EmailExsistFailedCException.class)
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
     protected CommonResult emailExsistFailedCException(HttpServletRequest request, EmailExsistFailedCException e) {
         log.info(e.getMessage());
         return responseService.getFailResult(e.getMessage());
     }
 
     @ExceptionHandler(UnMatchedUserCException.class)
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
     protected CommonResult unMathedUserException(HttpServletRequest request, UnMatchedUserCException e) {
         log.info(e.getMessage());
         return responseService.getFailResult(e.getMessage());
     }
     @ExceptionHandler(PostNotFoundCException.class)
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
     protected CommonResult postNotFoundException(HttpServletRequest request, PostNotFoundCException e) {
         log.info(e.getMessage());
         return responseService.getFailResult(e.getMessage());
     }
     @ExceptionHandler(CommentNotFoundCException.class)
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
     protected CommonResult commentNotFoundCException(HttpServletRequest request, CommentNotFoundCException e) {
         log.info(e.getMessage());
         return responseService.getFailResult(e.getMessage());

--- a/src/main/java/hello/postpractice/advice/exception/CommentNotFoundCException.java
+++ b/src/main/java/hello/postpractice/advice/exception/CommentNotFoundCException.java
@@ -1,8 +1,9 @@
 package hello.postpractice.advice.exception;
 
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
 public class CommentNotFoundCException extends RuntimeException{
-    public CommentNotFoundCException() {
-    }
 
     public CommentNotFoundCException(String message) {
         super(message);

--- a/src/main/java/hello/postpractice/advice/exception/EmailExsistFailedCException.java
+++ b/src/main/java/hello/postpractice/advice/exception/EmailExsistFailedCException.java
@@ -1,8 +1,9 @@
 package hello.postpractice.advice.exception;
 
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
 public class EmailExsistFailedCException extends RuntimeException {
-    public EmailExsistFailedCException() {
-    }
 
     public EmailExsistFailedCException(String message) {
         super(message);

--- a/src/main/java/hello/postpractice/advice/exception/EmailNotFailedCException.java
+++ b/src/main/java/hello/postpractice/advice/exception/EmailNotFailedCException.java
@@ -1,9 +1,9 @@
 package hello.postpractice.advice.exception;
 
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
 public class EmailNotFailedCException extends RuntimeException {
-    public EmailNotFailedCException() {
-        super();
-    }
     public EmailNotFailedCException(String message) {
         super(message);
     }

--- a/src/main/java/hello/postpractice/advice/exception/PasswordFailCException.java
+++ b/src/main/java/hello/postpractice/advice/exception/PasswordFailCException.java
@@ -1,9 +1,9 @@
 package hello.postpractice.advice.exception;
 
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
 public class PasswordFailCException extends RuntimeException{
-    public PasswordFailCException() {
-        super();
-    }
     
     public PasswordFailCException(String message) {
         super(message);

--- a/src/main/java/hello/postpractice/advice/exception/PostNotFoundCException.java
+++ b/src/main/java/hello/postpractice/advice/exception/PostNotFoundCException.java
@@ -1,8 +1,9 @@
 package hello.postpractice.advice.exception;
 
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
 public class PostNotFoundCException extends RuntimeException{
-    public PostNotFoundCException() {
-    }
 
     public PostNotFoundCException(String message) {
         super(message);

--- a/src/main/java/hello/postpractice/advice/exception/UnMatchedUserCException.java
+++ b/src/main/java/hello/postpractice/advice/exception/UnMatchedUserCException.java
@@ -1,8 +1,9 @@
 package hello.postpractice.advice.exception;
 
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
 public class UnMatchedUserCException extends RuntimeException{
-    public UnMatchedUserCException() {
-    }
 
     public UnMatchedUserCException(String message) {
         super(message);

--- a/src/main/java/hello/postpractice/advice/exception/UserNotFoundCException.java
+++ b/src/main/java/hello/postpractice/advice/exception/UserNotFoundCException.java
@@ -1,9 +1,9 @@
 package hello.postpractice.advice.exception;
 
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
 public class UserNotFoundCException extends RuntimeException {
-        public UserNotFoundCException() {
-                super();
-        }
 
         public UserNotFoundCException(String message) {
                 super(message);

--- a/src/main/java/hello/postpractice/controller/PostController.java
+++ b/src/main/java/hello/postpractice/controller/PostController.java
@@ -38,8 +38,8 @@ public class PostController {
 
     @GetMapping("/{id}")
     public SingleResult<PostDto> getpost(@PathVariable Long id){
-        PostDto PostDto = postService.getResponseDtoPost(id);
-        return responseService.getSingleResult(PostDto);
+        PostDto postDto = postService.getResponseDtoPost(id);
+        return responseService.getSingleResult(postDto);
     }
     @PostMapping
     public SingleResult<PostDto> create(@RequestBody PostDto postDto){


### PR DESCRIPTION
client 에서는 server error인 500을 보게 해서는 안되는데, 나는 모든 에러를 모두 500대로 하고있었다.

각각 HttpStatus에 알맞게

400 Bad Request

401 권한 오류 (적당한 권한을 가진애로가져와라

403 숨기고싶은것 (금지된항목, 권한으로 해결되지않은 항목)

404 NotFound(API에서 공개하지않았고, 찾아지지 않았을때 보여주느것)

등으로 각자 알맞게 사용하여 변경하였다

[https://stackoverflow.com/questions/1959947/whats-an-appropriate-http-status-code-to-return-by-a-rest-api-service-for-a-val](https://stackoverflow.com/questions/1959947/whats-an-appropriate-http-status-code-to-return-by-a-rest-api-service-for-a-val)