### PR TITLE
updateAuthLogicwithValidation

### DIFF
--- a/src/main/java/hello/postpractice/domain/UserSignupRequestDto.java
+++ b/src/main/java/hello/postpractice/domain/UserSignupRequestDto.java
@@ -2,6 +2,8 @@ package hello.postpractice.domain;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.management.relation.Role;
 import javax.validation.constraints.NotBlank;
@@ -16,10 +18,17 @@ import java.util.Collections;
 @Getter
 public class UserSignupRequestDto {
 
+    @NotEmpty
+    @Size(max=30)
     private String email;
+
+    @NotEmpty
+    @Size(max=30)
     private String password;
+    @Size(max=30)
     private String nickname;
 
+    @NotEmpty
     private String auth;
 
     @Builder


### PR DESCRIPTION
### SignController

- signupMap.get()활용시 값이 없을 경우, 값이 들어오지 않았을경우 default값으로 처리
- validation을 이용하여 아래와같이 개선하였다.

```java
아래 문제점을 개선하였다

public class SignController {
...
@PostMapping("/signup")
    public SingleResult<Long> signup(@RequestBody Map<String, String> signupMap){
        String email = signupMap.get("email");
        String password = signupMap.get("password");
        String nickname = signupMap.get("nickname");
        String auth = signupMap.get("auth");
        if (auth.isEmpty()) {
            auth = "ROLE_USER"; //""이라면 ROLE_USER 로 default
        } else {
            auth = signupMap.get("auth");  //"ROLE_USER,ROLE_ADMIN" 이런식으로 들어옴
        }

        UserSignupRequestDto userSignupRequestDto = UserSignupRequestDto.builder()
                .email(email)
                .password(passwordEncoder.encode(password))
                .nickname(nickname)
                .auth(auth)
                .build();
        Long signupId = userService.signup(userSignupRequestDto);
        return responseService.getSingleResult(signupId);
    }
...
}
```

- 위 형태를 validation으로 축소시킴

```java
@PostMapping("/signup")
    public SingleResult<Long> signup(@Validated @RequestBody UserSignupRequestDto requestuserSignupRequestDto, BindingResult bindingResult){
        if (bindingResult.hasErrors()){
            List<String> errors = bindingResult.getAllErrors().stream().map(e->e.getDefaultMessage()).collect(Collectors.toList());
            throw new DataFieldInvalidCException(errors);
        }
        UserSignupRequestDto userSignupRequestDto = UserSignupRequestDto.builder()
                .email(requestuserSignupRequestDto.getEmail())
                .password(passwordEncoder.encode(requestuserSignupRequestDto.getPassword())) //password 암호화시 password이런식으로 다시 꺼내와줘야하나?
                .nickname(requestuserSignupRequestDto.getNickname())
                .auth(requestuserSignupRequestDto.getAuth())
                .build();
        Long signupId = userService.signup(userSignupRequestDto);
        return responseService.getSingleResult(signupId);
    }
```

### UserSignupRequestDto

- User 저장시 사용하는 UserDto를 반드시 알맞게 수정
- @validation 처리

```java
public class UserSignupRequestDto {

    @NotEmpty
    @Size(max=30)
    private String email;

    @NotEmpty
    @Size(max=30)
    private String password;
    @Size(max=30)
    private String nickname;

    @NotEmpty
    private String auth;

    @Builder
    public UserSignupRequestDto(String email, String password, String nickname, String auth) {
        this.email = email;
        this.password = password;
        this.nickname = nickname;
        this.auth = auth;
    }

    public User toEntity() {
        return User.builder()
                .email(email)
                .password(password)
                .nickname(nickname)
                .auth(auth)
                .build();
    }
}
```